### PR TITLE
Add line chart to display GWA trend

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "anoGWAmo?",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Computes cumulative GWA from PUP SIS grades, excludes non-academic subjects, and checks Latin Honors eligibility.",
   "permissions": [],
   "host_permissions": [
@@ -16,8 +16,8 @@
         "https://sis2.pup.edu.ph/student/grades*",
         "https://sis8.pup.edu.ph/student/grades*"
       ],
-      "js": ["src/content.js"],
-      "css": ["src/styles.css"],
+      "js": ["src/gwa-chart.js", "src/content.js"],
+      "css": ["src/gwa-chart.css", "src/styles.css"],
       "run_at": "document_idle"
     }
   ],

--- a/src/content.js
+++ b/src/content.js
@@ -354,6 +354,59 @@ function createPanel(semesters) {
   const panel = document.createElement("div");
   panel.id = "pup-gwa-panel";
 
+  let chartInstance = null;
+
+  function renderChartData() {
+    const container = panel.querySelector('#pup-gwa-chart-wrapper');
+    if (!container || typeof GWAChart === 'undefined') return;
+
+    if (chartInstance) {
+      chartInstance.destroy();
+      chartInstance = null;
+    }
+
+    const chartData = [];
+    
+    if (currentMode === "B") {
+      const { breakdown } = computeModeB(semesters);
+      breakdown.forEach(b => {
+        chartData.push({ semester: b.label, gwa: b.siteGpa });
+      });
+    } else {
+      semesters.forEach(sem => {
+        let semPts = 0, semUnits = 0;
+        sem.subjects.forEach(subj => {
+          if (!subj.isNonAcademic && subj.grade !== null && subj.units !== null) {
+            semPts += subj.grade * subj.units;
+            semUnits += subj.units;
+          }
+        });
+        if (semUnits > 0) {
+          chartData.push({ semester: sem.label, gwa: semPts / semUnits });
+        }
+      });
+    }
+
+    if (chartData.length < 2) {
+      container.style.display = 'none';
+      return;
+    }
+    
+    container.style.display = 'block';
+
+    // Reverse to show older semesters first (assuming data is newest first like PUPSIS typically is)
+    chartData.reverse();
+
+    chartInstance = new GWAChart(container, {
+      targetGWA: 1.60,
+      lineColor: '#800000', // PUP Maroon
+      fillStart: 'rgba(128, 0, 0, 0.3)',
+      fillEnd: 'rgba(128, 0, 0, 0.0)'
+    });
+
+    chartInstance.renderChart(chartData);
+  }
+
   function render() {
     panel.innerHTML = `
       <div class="pup-gwa-header">
@@ -367,6 +420,7 @@ function createPanel(semesters) {
         </div>
       </div>
       <div class="pup-gwa-body">
+        <div id="pup-gwa-chart-wrapper" style="width: 100%; margin-bottom: 24px; display: none;"></div>
         ${currentMode === "B" ? renderModeB(semesters, disqData) : renderModeA(semesters, disqData)}
       </div>`;
 
@@ -388,6 +442,9 @@ function createPanel(semesters) {
 
     // Initial theme sync
     syncPanelTheme(panel);
+    
+    // Render the chart after DOM is updated
+    setTimeout(renderChartData, 0);
   }
 
   render();

--- a/src/gwa-chart.css
+++ b/src/gwa-chart.css
@@ -1,0 +1,45 @@
+.gwa-chart-container {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  min-height: 250px;
+}
+
+.gwa-chart-container canvas {
+  display: block;
+  outline: none;
+}
+
+.gwa-chart-tooltip {
+  position: absolute;
+  pointer-events: none;
+  background-color: rgba(30, 30, 30, 0.9);
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 13px;
+  line-height: 1.4;
+  z-index: 1000;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  transition: opacity 0.2s, transform 0.1s;
+  opacity: 0;
+  transform: translateY(5px);
+  /* Hidden by default visually but structure exists */
+}
+
+.gwa-chart-tooltip.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.gwa-chart-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: rgba(30, 30, 30, 0.9) transparent transparent transparent;
+}

--- a/src/gwa-chart.js
+++ b/src/gwa-chart.js
@@ -1,0 +1,349 @@
+class GWAChart {
+  constructor(container, options = {}) {
+    this.container = typeof container === 'string' ? document.querySelector(container) : container;
+    
+    // Create canvas
+    this.canvasDiv = document.createElement('div');
+    this.canvasDiv.className = 'gwa-chart-container';
+    this.canvasDiv.style.position = 'relative';
+    this.canvasDiv.style.width = '100%';
+    this.canvasDiv.style.height = '100%';
+    this.canvasDiv.style.minHeight = '320px';
+    
+    this.canvas = document.createElement('canvas');
+    this.canvas.style.display = 'block';
+    this.canvas.style.outline = 'none';
+    this.canvasDiv.appendChild(this.canvas);
+    this.container.appendChild(this.canvasDiv);
+    
+    this.ctx = this.canvas.getContext('2d');
+    
+    this.options = {
+      lineColor: '#800000', // PUP Maroon
+      fillStart: 'rgba(128, 0, 0, 0.4)',
+      fillEnd: 'rgba(128, 0, 0, 0.0)',
+      targetGWA: null,
+      targetColor: '#ff6b6b',
+      gridColor: '#e0e0e0',
+      textColor: '#888',
+      pointRadius: 4,
+      pointHoverRadius: 6,
+      font: '12px system-ui, -apple-system, sans-serif',
+      ...options
+    };
+    
+    this.margins = { top: 30, right: 20, bottom: 40, left: 40 };
+    
+    this.data = [];
+    this.points = [];
+    this.hoverIndex = -1;
+    this.tooltip = this.createTooltip();
+    
+    // Bind methods
+    this.handleMouseMove = this.handleMouseMove.bind(this);
+    this.handleMouseLeave = this.handleMouseLeave.bind(this);
+    this.handleResize = this.handleResize.bind(this);
+    
+    // Event listeners
+    this.canvas.addEventListener('mousemove', this.handleMouseMove);
+    this.canvas.addEventListener('mouseleave', this.handleMouseLeave);
+    window.addEventListener('resize', this.handleResize);
+  }
+
+  createTooltip() {
+    const tooltip = document.createElement('div');
+    tooltip.className = 'gwa-chart-tooltip';
+    document.body.appendChild(tooltip);
+    return tooltip;
+  }
+
+  destroy() {
+    this.canvas.removeEventListener('mousemove', this.handleMouseMove);
+    this.canvas.removeEventListener('mouseleave', this.handleMouseLeave);
+    window.removeEventListener('resize', this.handleResize);
+    if (this.tooltip && this.tooltip.parentNode) {
+      this.tooltip.parentNode.removeChild(this.tooltip);
+    }
+  }
+
+  handleResize() {
+    if (this.data.length > 0) {
+      this.renderChart(this.data);
+    }
+  }
+
+  handleMouseMove(e) {
+    if (!this.data || this.data.length === 0) return;
+    
+    const rect = this.canvas.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    
+    // Find closest point (X-axis distance)
+    let closestIdx = -1;
+    let minDistance = Infinity;
+    
+    for (let i = 0; i < this.points.length; i++) {
+        const p = this.points[i];
+        const dist = Math.abs(p.x - x);
+        if (dist < 30 && dist < minDistance) {
+            minDistance = dist;
+            closestIdx = i;
+        }
+    }
+    
+    if (closestIdx !== this.hoverIndex) {
+        this.hoverIndex = closestIdx;
+        this.draw(); // Redraw for hover highlight
+        
+        if (closestIdx !== -1) {
+            const point = this.points[closestIdx];
+            const item = this.data[closestIdx];
+            
+            this.tooltip.innerHTML = `<strong>${item.semester}</strong><br/>GWA: <strong>${item.gwa.toFixed(4)}</strong>`;
+            this.tooltip.classList.add('visible');
+            
+            const tooltipRect = this.tooltip.getBoundingClientRect();
+            let left = rect.left + point.x - tooltipRect.width / 2;
+            let top = rect.top + point.y - tooltipRect.height - 15;
+            
+            if (top < 0) top = rect.top + point.y + 15;
+            
+            this.tooltip.style.left = `${left + window.scrollX}px`;
+            this.tooltip.style.top = `${top + window.scrollY}px`;
+        } else {
+            this.tooltip.classList.remove('visible');
+        }
+    }
+  }
+
+  handleMouseLeave() {
+    this.hoverIndex = -1;
+    this.tooltip.classList.remove('visible');
+    this.draw();
+  }
+
+  renderChart(data) {
+    this.data = data;
+    
+    // High DPI scaling
+    const rect = this.canvasDiv.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+    this.canvas.width = rect.width * dpr;
+    this.canvas.height = rect.height * dpr;
+    
+    this.ctx.scale(dpr, dpr);
+    this.canvas.style.width = `${rect.width}px`;
+    this.canvas.style.height = `${rect.height}px`;
+    
+    this.cssWidth = rect.width;
+    this.cssHeight = rect.height;
+    
+    this.calculateLayout();
+    this.draw();
+  }
+
+  calculateLayout() {
+    const { cssWidth: width, cssHeight: height } = this;
+    const margins = this.margins;
+    
+    const innerWidth = width - margins.left - margins.right;
+    const innerHeight = height - margins.top - margins.bottom;
+    
+    this.innerWidth = innerWidth;
+    this.innerHeight = innerHeight;
+    
+    // Adaptive Scaling
+    if (this.data.length > 0) {
+        let minVal = Math.min(...this.data.map(d => d.gwa));
+        let maxVal = Math.max(...this.data.map(d => d.gwa));
+        
+        if (minVal === maxVal) {
+            minVal -= 0.1;
+            maxVal += 0.1;
+        }
+        
+        const rangeMargin = (maxVal - minVal) * 0.2;
+        this.topGwa = Math.max(1.0, Math.floor((minVal - rangeMargin) * 10) / 10);
+        this.bottomGwa = Math.min(5.0, Math.ceil((maxVal + rangeMargin) * 10) / 10);
+        
+        // Ensure minimum vertical spread
+        if (this.bottomGwa - this.topGwa < 0.2) {
+            this.topGwa = Math.max(1.0, this.topGwa - 0.1);
+            this.bottomGwa = Math.min(5.0, this.bottomGwa + 0.1);
+        }
+    } else {
+        this.topGwa = 1.0;
+        this.bottomGwa = 5.0;
+    }
+    
+    const yRange = this.bottomGwa - this.topGwa;
+    
+    this.points = this.data.map((item, index) => {
+        const x = margins.left + (index * (innerWidth / Math.max(1, this.data.length - 1)));
+        const normalizedGwa = (item.gwa - this.topGwa) / yRange;
+        const y = margins.top + (normalizedGwa * innerHeight);
+        return { x, y, value: item.gwa, label: item.semester };
+    });
+  }
+
+  draw() {
+    const { ctx, cssWidth: width, cssHeight: height } = this;
+    
+    ctx.clearRect(0, 0, width, height);
+    
+    if (this.data.length === 0) return;
+    
+    this.drawGrid();
+    
+    if (this.options.targetGWA !== null) {
+        this.drawTargetLine(this.options.targetGWA);
+    }
+    
+    this.drawLine();
+    this.drawPoints();
+  }
+
+  drawGrid() {
+    const { ctx, cssWidth: width, cssHeight: height } = this;
+    const { gridColor, textColor, font } = this.options;
+    const margins = this.margins;
+    
+    ctx.font = font;
+    ctx.fillStyle = textColor;
+    ctx.strokeStyle = gridColor;
+    ctx.lineWidth = 1;
+    ctx.textBaseline = 'middle';
+    
+    // Adaptive Y-axis ticks
+    const steps = 4;
+    for (let i = 0; i <= steps; i++) {
+        const gwa = this.topGwa + (i / steps) * (this.bottomGwa - this.topGwa);
+        const y = margins.top + (i / steps) * this.innerHeight;
+        
+        ctx.textAlign = 'right';
+        ctx.fillText(gwa.toFixed(2), margins.left - 10, y);
+        
+        ctx.save();
+        ctx.setLineDash([5, 5]);
+        ctx.beginPath();
+        ctx.moveTo(margins.left, Math.round(y) - 0.5);
+        ctx.lineTo(width - margins.right, Math.round(y) - 0.5);
+        ctx.stroke();
+        ctx.restore();
+    }
+    
+    // Labels X
+    const xLabels = this.data.length;
+    const stepX = Math.ceil(xLabels / (this.innerWidth / 40)); 
+
+    for (let i = 0; i < xLabels; i += stepX) {
+        const p = this.points[i];
+        
+        ctx.save();
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'top';
+        ctx.fillText((i + 1).toString(), p.x, height - margins.bottom + 10);
+        ctx.restore();
+    }
+  }
+
+  drawTargetLine(target) {
+     const { ctx, cssWidth: width } = this;
+     const { targetColor } = this.options;
+     const margins = this.margins;
+     
+     if (target < this.topGwa || target > this.bottomGwa) return;
+     
+     const yRange = this.bottomGwa - this.topGwa;
+     const normalized = (target - this.topGwa) / yRange;
+     const y = margins.top + normalized * this.innerHeight;
+     
+     ctx.save();
+     ctx.strokeStyle = targetColor;
+     ctx.lineWidth = 1.5;
+     ctx.setLineDash([6, 4]);
+     ctx.beginPath();
+     ctx.moveTo(margins.left, Math.round(y) - 0.5);
+     ctx.lineTo(width - margins.right, Math.round(y) - 0.5);
+     ctx.stroke();
+     ctx.restore();
+     
+     ctx.fillStyle = targetColor;
+     ctx.textAlign = 'left';
+     ctx.textBaseline = 'bottom';
+     ctx.fillText(`Target (${target})`, margins.left, y - 4);
+  }
+
+  drawLine() {
+    const { ctx, cssHeight: height } = this;
+    const { lineColor, fillStart, fillEnd } = this.options;
+    const margins = this.margins;
+    
+    if (this.points.length < 2) return;
+    
+    ctx.beginPath();
+    ctx.moveTo(this.points[0].x, this.points[0].y);
+    
+    // Bezier Curves
+    for (let i = 0; i < this.points.length - 1; i++) {
+        const p1 = this.points[i];
+        const p2 = this.points[i + 1];
+        
+        const cp1x = p1.x + (p2.x - p1.x) / 2;
+        const cp1y = p1.y;
+        const cp2x = p1.x + (p2.x - p1.x) / 2;
+        const cp2y = p2.y;
+        
+        ctx.bezierCurveTo(cp1x, cp1y, cp2x, cp2y, p2.x, p2.y);
+    }
+    
+    // Fill Area under line
+    ctx.lineTo(this.points[this.points.length - 1].x, height - margins.bottom);
+    ctx.lineTo(this.points[0].x, height - margins.bottom);
+    ctx.closePath();
+    
+    const gradient = ctx.createLinearGradient(0, margins.top, 0, height - margins.bottom);
+    gradient.addColorStop(0, fillStart);
+    gradient.addColorStop(1, fillEnd);
+    ctx.fillStyle = gradient;
+    ctx.fill();
+    
+    // Draw Stroke
+    ctx.beginPath();
+    ctx.moveTo(this.points[0].x, this.points[0].y);
+    for (let i = 0; i < this.points.length - 1; i++) {
+        const p1 = this.points[i];
+        const p2 = this.points[i + 1];
+        const cp1x = p1.x + (p2.x - p1.x) / 2;
+        const cp1y = p1.y;
+        const cp2x = p1.x + (p2.x - p1.x) / 2;
+        const cp2y = p2.y;
+        ctx.bezierCurveTo(cp1x, cp1y, cp2x, cp2y, p2.x, p2.y);
+    }
+    ctx.strokeStyle = lineColor;
+    ctx.lineWidth = 3;
+    ctx.lineJoin = 'round';
+    ctx.lineCap = 'round';
+    ctx.stroke();
+  }
+
+  drawPoints() {
+    const { ctx } = this;
+    const { lineColor, pointRadius, pointHoverRadius } = this.options;
+    
+    for (let i = 0; i < this.points.length; i++) {
+        const p = this.points[i];
+        const isHovered = i === this.hoverIndex;
+        const radius = isHovered ? pointHoverRadius : pointRadius;
+        
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, radius, 0, Math.PI * 2);
+        ctx.fillStyle = '#ffffff';
+        ctx.fill();
+        ctx.strokeStyle = lineColor;
+        ctx.lineWidth = isHovered ? 3 : 2;
+        ctx.stroke();
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces a new interactive GWA (General Weighted Average) chart feature to the extension, allowing users to visually track their GWA trends per semester. The main changes include adding a custom chart component, updating the manifest to include new assets, and integrating the chart into the panel UI. The chart is rendered with a custom JavaScript class and styled with a dedicated CSS file.

**Feature: GWA Chart Visualization**

* Added a new `GWAChart` class in `src/gwa-chart.js` to render an interactive line chart for GWA trends, including tooltips, target lines, and responsive resizing.
* Created a new stylesheet `src/gwa-chart.css` for the chart's container and tooltip styling.

**Integration with Panel UI**

* Updated `src/content.js` to render the GWA chart in the panel, including logic to compute and display per-semester GWA data and handle mode switching. Chart is only shown if there are at least two semesters of data. [[1]](diffhunk://#diff-1f93cd4783614fe92bbb9d7fba4cd2b31ba1a47c0c2e9b00be36bd3246e5af7fR357-R409) [[2]](diffhunk://#diff-1f93cd4783614fe92bbb9d7fba4cd2b31ba1a47c0c2e9b00be36bd3246e5af7fR423) [[3]](diffhunk://#diff-1f93cd4783614fe92bbb9d7fba4cd2b31ba1a47c0c2e9b00be36bd3246e5af7fR445-R447)

**Manifest and Asset Updates**

* Updated `manifest.json` to version 1.1.0 and included the new chart JavaScript and CSS files in the extension's content scripts. [[1]](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743L4-R4) [[2]](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743L19-R20)