### PR TITLE
🧪 Add unit tests for core utility functions

### DIFF
--- a/src/core/utils.test.js
+++ b/src/core/utils.test.js
@@ -1,0 +1,74 @@
+import { expect, test, describe } from "bun:test";
+import { honorFor, isNonAcademic, parseGrade, honorColor } from "./utils.js";
+
+describe("utils.js", () => {
+  describe("isNonAcademic", () => {
+    test("identifies non-academic courses", () => {
+      expect(isNonAcademic("PATHFIT 1")).toBe(true);
+      expect(isNonAcademic("NSTP 1")).toBe(true);
+      expect(isNonAcademic("CWTS 1")).toBe(true);
+      expect(isNonAcademic("ROTC 1")).toBe(true);
+      expect(isNonAcademic("pathfit 2")).toBe(true);
+    });
+
+    test("identifies academic courses", () => {
+      expect(isNonAcademic("COMP 20083")).toBe(false);
+      expect(isNonAcademic("MATH 20013")).toBe(false);
+    });
+  });
+
+  describe("parseGrade", () => {
+    test("parses valid grades", () => {
+      expect(parseGrade("1.0")).toBe(1.0);
+      expect(parseGrade("1.25")).toBe(1.25);
+      expect(parseGrade("3.0")).toBe(3.0);
+    });
+
+    test("handles null, empty, or invalid input", () => {
+      expect(parseGrade(null)).toBe(null);
+      expect(parseGrade("")).toBe(null);
+      expect(parseGrade("  ")).toBe(null);
+      expect(parseGrade("INC")).toBe(null);
+    });
+  });
+
+  describe("honorFor", () => {
+    test("returns null for null GWA", () => {
+      expect(honorFor(null)).toBe(null);
+    });
+
+    test("identifies Summa Cum Laude boundaries", () => {
+      expect(honorFor(1.0000)).toBe("Summa Cum Laude");
+      expect(honorFor(1.1500)).toBe("Summa Cum Laude");
+    });
+
+    test("identifies Magna Cum Laude boundaries", () => {
+      expect(honorFor(1.1501)).toBe("Magna Cum Laude");
+      expect(honorFor(1.3500)).toBe("Magna Cum Laude");
+    });
+
+    test("identifies Cum Laude boundaries", () => {
+      expect(honorFor(1.3501)).toBe("Cum Laude");
+      expect(honorFor(1.6000)).toBe("Cum Laude");
+    });
+
+    test("returns null for GWAs outside honor ranges", () => {
+      expect(honorFor(1.6001)).toBe(null);
+      expect(honorFor(2.0)).toBe(null);
+      expect(honorFor(5.0)).toBe(null);
+    });
+  });
+
+  describe("honorColor", () => {
+    test("returns correct colors for honor labels", () => {
+      expect(honorColor("Summa Cum Laude")).toBe("var(--pup-honor-summa)");
+      expect(honorColor("Magna Cum Laude")).toBe("var(--pup-honor-magna)");
+      expect(honorColor("Cum Laude")).toBe("var(--pup-honor-cumlaude)");
+    });
+
+    test("returns default color for unknown labels", () => {
+      expect(honorColor("No Honor")).toBe("var(--pup-honor-none)");
+      expect(honorColor(null)).toBe("var(--pup-honor-none)");
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
- Missing unit tests for the `honorFor` function in `src/core/utils.js` which is responsible for determining academic honors based on GWA thresholds.
- Additional coverage for related utility functions: `isNonAcademic`, `parseGrade`, and `honorColor`.

📊 **Coverage:** What scenarios are now tested
- `honorFor`: Null input, boundary values for Summa Cum Laude, Magna Cum Laude, and Cum Laude, and out-of-range GWA values.
- `isNonAcademic`: Recognition of non-academic course prefixes (PATHFIT, NSTP, CWTS, ROTC) and academic codes.
- `parseGrade`: Valid numeric strings, empty/null inputs, and invalid non-numeric strings.
- `honorColor`: Correct CSS variable mapping for each honor tier and default fallback.

✨ **Result:** The improvement in test coverage
- Increased the reliability of the academic honor calculation logic.
- Established a testing pattern for core utilities using the built-in Bun test runner.
- Ensured that edge cases like boundary thresholds are correctly handled according to the defined `HONORS` constants.

---
*PR created automatically by Jules for task [16059938116537004154](https://jules.google.com/task/16059938116537004154) started by @znarfm*